### PR TITLE
Add button linking to getting started page on overview

### DIFF
--- a/wiki/de/index.md
+++ b/wiki/de/index.md
@@ -5,3 +5,4 @@ lang: "de"
 permalink: "/wiki/"
 ---
 # Übersicht
+[Mit Jamulus loslegen](https://jamulus.io/de/wiki/Getting-Started){:.button}


### PR DESCRIPTION
Since the site https://jamulus.io/wiki/ ranks high on Google I highly suggest to add a prominent button to the Getting Started page there. This is a quite important fix which I think must be addressed before the freeze is over