### PR TITLE
Update to document new parameter for --ctrlmidich

### DIFF
--- a/wiki/en/en-Command-Line-Options.md
+++ b/wiki/en/en-Command-Line-Options.md
@@ -50,5 +50,5 @@ You can see all possible options your version supports by starting Jamulus with 
 |    `-u` |`--numchannels`    | Maximum number of channels. Default is 10, maximum is 50 | (server only) |
 |    `-w` |`--welcomemessage` | Supports HTML and inline CSS formatting (in enclosing quotes), or set path to text file. | (server only) |
 |    `-z` |`--startminimized` | Start minimized | (server only) |
-|       |`--ctrlmidich`     | MIDI controller channel to listen on and control number offset, format: `channel[;offset]` | (client only) see [Tips & Tricks](Tips-Tricks-More#Using-the-–ctrlmidich-MIDI-controller-channel-option) |
+|       |`--ctrlmidich`     | MIDI controller channel to listen on and control number offset, format: `channel[;offset]` | (client only) see [Tips & Tricks](Tips-Tricks-More#Using-–ctrlmidich-for-MIDI-controllers) |
 |       |`--clientname`     | Window title and jack client name | (client only) |

--- a/wiki/en/en-Command-Line-Options.md
+++ b/wiki/en/en-Command-Line-Options.md
@@ -50,5 +50,5 @@ You can see all possible options your version supports by starting Jamulus with 
 |    `-u` |`--numchannels`    | Maximum number of channels. Default is 10, maximum is 50 | (server only) |
 |    `-w` |`--welcomemessage` | Supports HTML and inline CSS formatting (in enclosing quotes), or set path to text file. | (server only) |
 |    `-z` |`--startminimized` | Start minimized | (server only) |
-|       |`--ctrlmidich`     | MIDI controller channel to listen on and control number offset, format `channel[;offset]` | (client only) see [Tips & Tricks](Tips-Tricks-More#Using-the-–ctrlmidich-MIDI-controller-channel-option) |
+|       |`--ctrlmidich`     | MIDI controller channel to listen on and control number offset, format: `channel[;offset]` | (client only) see [Tips & Tricks](Tips-Tricks-More#Using-the-–ctrlmidich-MIDI-controller-channel-option) |
 |       |`--clientname`     | Window title and jack client name | (client only) |

--- a/wiki/en/en-Command-Line-Options.md
+++ b/wiki/en/en-Command-Line-Options.md
@@ -50,5 +50,5 @@ You can see all possible options your version supports by starting Jamulus with 
 |    `-u` |`--numchannels`    | Maximum number of channels. Default is 10, maximum is 50 | (server only) |
 |    `-w` |`--welcomemessage` | Supports HTML and inline CSS formatting (in enclosing quotes), or set path to text file. | (server only) |
 |    `-z` |`--startminimized` | Start minimized | (server only) |
-|       |`--ctrlmidich`     | MIDI controller channel to listen on | (client only) see [Tips & Tricks](Tips-Tricks-More) |
+|       |`--ctrlmidich`     | MIDI controller channel to listen on and control number offset, format `channel[;offset]` | (client only) see [Tips & Tricks](Tips-Tricks-More#Using-the-–ctrlmidich-MIDI-controller-channel-option) |
 |       |`--clientname`     | Window title and jack client name | (client only) |

--- a/wiki/en/en-Command-Line-Options.md
+++ b/wiki/en/en-Command-Line-Options.md
@@ -50,5 +50,5 @@ You can see all possible options your version supports by starting Jamulus with 
 |    `-u` |`--numchannels`    | Maximum number of channels. Default is 10, maximum is 50 | (server only) |
 |    `-w` |`--welcomemessage` | Supports HTML and inline CSS formatting (in enclosing quotes), or set path to text file. | (server only) |
 |    `-z` |`--startminimized` | Start minimized | (server only) |
-|       |`--ctrlmidich`     | MIDI controller channel to listen on and control number offset, format: `channel[;offset]` | (client only) see [Tips & Tricks](Tips-Tricks-More#Using-–ctrlmidich-for-MIDI-controllers) |
+|       |`--ctrlmidich`     | MIDI controller channel to listen on and control number offset, format: `channel[;offset]` | (client only) see [Tips & Tricks](Tips-Tricks-More#Using-ctrlmidich-for-MIDI-controllers) |
 |       |`--clientname`     | Window title and jack client name | (client only) |

--- a/wiki/en/en-Tips-Tricks-More.md
+++ b/wiki/en/en-Tips-Tricks-More.md
@@ -98,9 +98,9 @@ jack_connect Jamulus:'output right' system:playback_2
 
 
 
-## Using --ctrlmidich for MIDI controllers
+## Using ctrlmidich for MIDI controllers
 
-The volume faders in the client's mixer window can be controlled using a MIDI controller (note: only available for use with MacOS and Linux). To enable this feature, Jamulus must be launched with `--ctrlmidich`. There are two parameters you can set: `Channel` and `Offset`. Set the first parameter to the channel you want Jamulus to listen on (0 for all channels) and the second parameter to the Control Number you want the first fader to react to. By default, the offset is 70 (for the Behringer X-Touch), which means that the first fader reacts to Control Number 70, the second to 71, and so on. 
+The volume faders in the client's mixer window can be controlled using a MIDI controller by using the `--ctrlmidich` parameter (note: only available for use with MacOS and Linux). To enable this feature, Jamulus must be launched with `--ctrlmidich`. There are two parameters you can set: `Channel` and `Offset`. Set the first parameter to the channel you want Jamulus to listen on (0 for all channels) and the second parameter to the Control Number you want the first fader to react to. By default, the offset is 70 (for the Behringer X-Touch), which means that the first fader reacts to Control Number 70, the second to 71, and so on. 
 
 So for example, if you're using a Behringer X-Touch, sending MIDI on channel 1 and leaving the offset at default, the command would look like this: `--ctrlmidich 1`. If you have a different controller, e.g. sending MIDI on channel 2 and starting with Control Number 30, the command would be as follows: `--ctrlmidich "2;30"`
 

--- a/wiki/en/en-Tips-Tricks-More.md
+++ b/wiki/en/en-Tips-Tricks-More.md
@@ -98,18 +98,10 @@ jack_connect Jamulus:'output right' system:playback_2
 
 
 
-## Using the --ctrlmidich MIDI controller channel option
+## Using --ctrlmidich for MIDI controllers
 
-Jamulus user [Ignotus](https://sourceforge.net/u/jammerman/profile/) writes: If you want to use a generic MIDI controller, you will need to either make adjustments to your controller or re-compile the sources:
+The volume faders in the client's mixer window can be controlled using a MIDI controller (note: only available for use with MacOS and Linux). To enable this feature, Jamulus must be launched with `--ctrlmidich`. There are two parameters you can set: `Channel` and `Offset`. Set the first parameter to the channel you want Jamulus to listen on (0 for all channels) and the second parameter to the Control Number you want the first fader to react to. By default, the offset is 70 (for the Behringer X-Touch), which means that the first fader reacts to Control Number 70, the second to 71, and so on. 
 
-Note: only available for use with MacOS and Linux.
+So for example, if you're using a Behringer X-Touch, sending MIDI on channel 1 and leaving the offset at default, the command would look like this: `--ctrlmidich 1`. If you have a different controller, e.g. sending MIDI on channel 2 and starting with Control Number 30, the command would be as follows: `--ctrlmidich "2;30"`
 
-MIDI CC messages consist of a Control Number, Controller Value, and Channel. Jamulus listens to the Control Number to know what fader to move, on the channel you specify when launching it with `--ctrlmidich`.
-
-The Jamulus client is set by default for use with the Behringer X-Touch, which apparently sends Control Numbers starting at 70, when Jamulus' faders are zero-indexed, which means there's a -70 offset coded into the source code that turns that 70 Control Number into a 0 for the first fader, 71 into 1 for the next, etc.
-
-If you can change the Control Number in your MIDI controller, just set it to 70 (71, 72, etc for subsequent faders). Launch Jamulus with `--ctrlmidich x` where 'x' is the MIDI channel you're using, or launch it with `--ctrlmidich 0` to listen to all channels, and you're done. Make sure you connect your MIDI device's output port to the Jamulus MIDI in port (Qjackctl (Linux), MIDI Studio (MacOS) or whatever you use for managing connections). In Linux you will need to install and launch a2jmidid so your device shows up in the MIDI tab in Qjackctl.
-
-If you can't change the Control Numbers in your controller, you will need to modify and re-compile the sources:
-In the file `src/soundbase.cpp`, go to line 290, remove the `- 70` at the end (not the semicolon) to use Control Number 0 for the first fader, or replace that number with the initial Control Number your MIDI device sends. Save, [compile](Compiling) and install.
-
+Make sure you connect your MIDI device's output port to the Jamulus MIDI in port (Qjackctl (Linux), MIDI Studio (MacOS) or whatever you use for managing connections). In Linux you will need to install and launch a2jmidid so your device shows up in the MIDI tab in Qjackctl.


### PR DESCRIPTION
The section I wrote on using MIDI controllers is now obsolete. The dilemma now is this: this feature is currently available in Jamulus in its updated form but the documentation won't reflect this change until the next release (as per the new procedure). This will be true for any new features that get added. So - do we continue to align documentation updates/translations with the release cycle, or should we follow a more organic process where at an arbitrary point we agree that there's enough new stuff in the changes branch to warrant a 'merge&squash/translation'?