### PR TITLE
JACK/Jack : consistency around the English pages

### DIFF
--- a/wiki/en/en-Command-Line-Options.md
+++ b/wiki/en/en-Command-Line-Options.md
@@ -35,7 +35,7 @@ You can see all possible options your version supports by starting Jamulus with 
 |    `-F` |`--fastupdate`     | 64 samples frame size mode. Reduces latency if clients connect with "Enable Small Network Buffers" option. Requires faster CPU to avoid dropouts, and more bandwidth to enabled clients. | (server only) |
 | `-h,-?` |`--help`           | This help text | (client and server) |
 |    `-i` |`--inifile`        | Set location of initialization file (overrides default) | (client (always) and server (with GUI)) |
-|    `-j` |`--nojackconnect`  | Disable auto Jack connections | (client only) |
+|    `-j` |`--nojackconnect`  | Disable auto JACK connections | (client only) |
 |    `-l` |`--log` | Enable logging, set path and file name | (server only) |
 |    `-m` |`--htmlstatus`     | Enable HTML status file, set path and file name | (server only) |
 |    `-M` |`--mutestream`     | Starts Jamulus in muted state | (client only) |

--- a/wiki/en/en-Compiling.md
+++ b/wiki/en/en-Compiling.md
@@ -80,4 +80,4 @@ Compiling with the `headless` flag means you can avoid installing some of the de
 
 1. If you are running Jamulus on Ubuntu/Debian, you will need all dependent packages to **compile** the binary, but to **run** the resulting headless Jamulus server you should only need `libqt5core5a`, `libqt5network5`, `libqt5xml5` and probably `libqt5concurrent5`. This may be useful for compiling/upgrading on one machine to run the binary on another (a Raspberry Pi, for example).
 
-1. Note that if you want to compile a GUI client on one machine and run it on another (eg a Raspberry Pi) you only need the dependencies listed for a [headless server](Server-Linux#running-a-headless-server) (see point above), only _with_ the Jack sound libraries.
+1. Note that if you want to compile a GUI client on one machine and run it on another (eg a Raspberry Pi) you only need the dependencies listed for a [headless server](Server-Linux#running-a-headless-server) (see point above), only _with_ the JACK sound libraries.

--- a/wiki/en/en-Server-Linux.md
+++ b/wiki/en/en-Server-Linux.md
@@ -34,8 +34,8 @@ The following guide is for running Jamulus as a "pure" server on **hardware with
 ### Compile sources, create a user
 
 
-1. [Get the sources](Installation-for-Linux#get-jamulus-sources), install the [dependent packages](Installation-for-Linux#install-dependencies) according to the Linux client install guide. Note that **you don't need to install the Jack package(s)** for a headless build. _If you plan to run headless on Gentoo, or are compiling under Ubuntu for use on another Ubuntu machine, [see the footnote](#what-does-the-headless-build-flag-do)._
-1. Compile the sources to ignore the Jack sound library:
+1. [Get the sources](Installation-for-Linux#get-jamulus-sources), install the [dependent packages](Installation-for-Linux#install-dependencies) according to the Linux client install guide. Note that **you don't need to install the JACK package(s)** for a headless build. _If you plan to run headless on Gentoo, or are compiling under Ubuntu for use on another Ubuntu machine, [see the footnote](#what-does-the-headless-build-flag-do)._
+1. Compile the sources to ignore the JACK sound library:
 
 ~~~
 qmake "CONFIG+=nosound headless" Jamulus.pro

--- a/wiki/en/en-Server-Rpi.md
+++ b/wiki/en/en-Server-Rpi.md
@@ -15,7 +15,7 @@ _Jamulus has been tested on a Raspberry Pi 4 2Gb by Jamulus user [SIVA Frédéri
 
 1. Edit [config.txt](https://www.raspberrypi.org/documentation/configuration/config-txt/) to enable boot without HDMI by adding `hdmi_force_hotplug=0`
 
-1. [Get the sources](Installation-for-Linux#get-jamulus-sources), install the [dependent packages](Installation-for-Linux#install-dependencies) according to the Linux client install guide **but do NOT install Jack package(s)** - you don't need them on a [headless server](Server-Linux#running-a-headless-server). To run a client, install all listed dependencies.
+1. [Get the sources](Installation-for-Linux#get-jamulus-sources), install the [dependent packages](Installation-for-Linux#install-dependencies) according to the Linux client install guide **but do NOT install JACK package(s)** - you don't need them on a [headless server](Server-Linux#running-a-headless-server). To run a client, install all listed dependencies.
 
 1. Compile the source code for a server as per [these instructions](Server-Linux#compile-sources-create-a-user). Compile a client using the [default instructions](Installation-for-Linux#compile-this-bad-boy).
 

--- a/wiki/en/en-Software-Manual.md
+++ b/wiki/en/en-Software-Manual.md
@@ -179,7 +179,7 @@ In this case the buffer delay setting is disabled and has to be changed using th
 
 ![Buffer delay Windows](https://user-images.githubusercontent.com/20726856/97361808-65ff5b80-18a0-11eb-88d6-fb2131f10c75.png)
 
-On Linux, use the Jack configuration tool to change the buffer size.
+On Linux, use the JACK configuration tool to change the buffer size.
 
 The actual buffer delay has influence on the connection status, the current upload rate and the overall delay.
 The lower the buffer size, the higher the probability of a red light in the status indicator (drop outs) and the

--- a/wiki/en/en-Tips-Tricks-More.md
+++ b/wiki/en/en-Tips-Tricks-More.md
@@ -15,7 +15,7 @@ Jamulus user [Chris Rimple](https://sourceforge.net/u/chrisrimple/profile/) has 
 
 ##  Using Jamulus audio in Zoom (or other) meeting apps
 
-Several users have reported success allowing a "virtual audience" for a Jamulus session by using [Jack audio](https://jackaudio.org) to route the Jamulus signal through the JackRouter to the target application (in this case, Zoom meetings). 
+Several users have reported success allowing a "virtual audience" for a Jamulus session by using [JACK audio](https://jackaudio.org) to route the Jamulus signal through the JackRouter to the target application (in this case, Zoom meetings). 
 
 You can also use [VoiceMeeter](https://www.vb-audio.com/Voicemeeter/banana.htm) (Banana) for Windows or [BlackHole](https://github.com/ExistentialAudio/BlackHole) for Mac to route Jamulus output to multiple destinations, for example to your headphones and the meeting application at the same time.
 


### PR DESCRIPTION
Hi, I've saw a bit of a mix between the way it's written in the different pages.

JACK is an acronym (a recursive one) meaning: JACK Audio Connection Kit.
Hence here is a first argument to keep it written in capital letter.
Another argument is that it helps with disambiguating "JACK" the software, and "jack" an audio cable (guitar,...).

Here is a PR for the few occurrences fixes I found around the English pages.

HTH