### PR TITLE
Add AGENTS.md for AI-agent contributors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Docs: [README.md](README.md) (workflow, translation process, branch targeting), 
 
 - Smallest possible PRs: one logical change each.
 - Edit English source `.md` files only — never hand-edit translated-language files or `.po` files; those belong to translators via Weblate.
-- **No smart/curly quotes or apostrophes** (`’ “ ”`) — always straight ASCII `'` and `"`. This isn't a style preference: a curly character pasted into a shell single-quoted string, JSON, a regex, or a code span is not the character the parser expects, and corrupts it silently. Word/Google Docs autocorrect and some LLM output insert these by default — check for them explicitly before opening a PR, especially near any code span or CLI example.
+- **Punctuation**: follow the Punctuation section in Style-and-Tone.md (dash/hyphen choice, curly vs. straight quotes, ellipsis). Word/Google Docs autocorrect and some LLM output insert curly characters by default even inside code — before opening a PR, check your diff specifically for stray curly quotes/dashes near any code span, CLI example, or other machine-parsed value.
 - Prefer hedged phrasing over absolute claims where the claim isn't a hard limit (e.g. "discouraged" over "not recommended", "up to N" over "less than N") — follows the guide's "give solutions first, avoid overly stylised language" principle.
 - British English spelling (colour, minimise, centre).
 - Match established terminology exactly: Server/Client (capitalised = a Jamulus app instance) vs. server/client (lowercase = the physical/cloud machine); "person" not "musician"; "sound card" vs. "audio interface" — full list in Style-and-Tone.md.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# Jamulus Website — Agent Instructions
+
+Content repo for jamulus.io (wiki/docs). English is the source of truth — edits land in English first, then flow to other languages via Weblate/po4a.
+
+Docs: [README.md](README.md) (workflow, translation process, branch targeting), [Style and Tone guide](https://jamulus.io/contribute/Style-and-Tone) (voice, terminology, capitalisation — applies to agents without exception).
+
+## Rules
+
+- Smallest possible PRs: one logical change each.
+- Edit English source `.md` files only — never hand-edit translated-language files or `.po` files; those belong to translators via Weblate.
+- **No smart/curly quotes or apostrophes** (`’ “ ”`) — always straight ASCII `'` and `"`. This isn't a style preference: a curly character pasted into a shell single-quoted string, JSON, a regex, or a code span is not the character the parser expects, and corrupts it silently. Word/Google Docs autocorrect and some LLM output insert these by default — check for them explicitly before opening a PR, especially near any code span or CLI example.
+- Prefer hedged phrasing over absolute claims where the claim isn't a hard limit (e.g. "discouraged" over "not recommended", "up to N" over "less than N") — follows the guide's "give solutions first, avoid overly stylised language" principle.
+- British English spelling (colour, minimise, centre).
+- Match established terminology exactly: Server/Client (capitalised = a Jamulus app instance) vs. server/client (lowercase = the physical/cloud machine); "person" not "musician"; "sound card" vs. "audio interface" — full list in Style-and-Tone.md.
+
+## Submit
+
+- Target `next-release` if the change needs translation, `release` if not (README's workflow section explains which).
+- Fill out the PR template checklist.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,21 +1,24 @@
-# Jamulus Website — Agent Instructions
+# Jamulus Website - Agent Instructions
 
-Content repo for jamulus.io (wiki/docs). English is the source of truth — edits land in English first, then flow to other languages via Weblate/po4a.
+Content repo for jamulus.io. English is the source of truth: edits land in English first, then flow to other languages via Weblate/po4a.
 
-Docs: [README.md](README.md) (workflow, translation process, branch targeting), [Style and Tone guide](https://jamulus.io/contribute/Style-and-Tone) (voice, terminology, capitalisation — applies to agents without exception).
+Read first: [README.md](README.md) (workflow, translation, branches) and the [Style and Tone guide](https://jamulus.io/contribute/Style-and-Tone) (voice, terminology, spelling). The guide governs; this file does not restate or override it.
+
+## Changes
+
+This is documentation, not code. The bar is: **is this better than what is there now?** Not complete, not final - better. A page that answers a reader's question one step sooner is worth submitting on its own.
+
+- One logical improvement per PR. Open several small PRs rather than one large one, and keep each reviewable.
+- Never hold a documentation fix behind a code change. Pages ship on their own schedule.
+- If you cannot tell whether your version is better, say so in the PR description instead of guessing.
 
 ## Rules
 
-- Smallest possible PRs: one logical change each.
-- Edit English source `.md` files only — never hand-edit translated-language files or `.po` files; those belong to translators via Weblate.
-- **Punctuation**: follow the Punctuation section in Style-and-Tone.md (dash/hyphen choice, curly vs. straight quotes, ellipsis). Word/Google Docs autocorrect and some LLM output insert curly characters by default even inside code — before opening a PR, check your diff specifically for stray curly quotes/dashes near any code span, CLI example, or other machine-parsed value.
-- Prefer hedged phrasing over absolute claims where the claim isn't a hard limit (e.g. "discouraged" over "not recommended", "up to N" over "less than N") — follows the guide's "give solutions first, avoid overly stylised language" principle.
+- Edit English source `.md` files only. Never hand-edit translated files or `.po` files - those belong to translators via Weblate.
+- Plain ASCII (`-` `'` `"`) inside anything parsed or copy-pasted: code, CLI flags, URLs, frontmatter, dates, versions. Autocorrect and LLM output break this by default; check your diff.
 - British English spelling (colour, minimise, centre).
-- Match established terminology exactly: Server/Client (capitalised = a Jamulus app instance) vs. server/client (lowercase = the physical/cloud machine); "person" not "musician"; "sound card" vs. "audio interface" — full list in Style-and-Tone.md.
 
-## Submit
+## Submitting
 
-- Branch targeting is genuinely case by case (maintainers' own assessment) — there's no reliable rule like "translated content → next-release." Mechanically: a merge to `release` publishes to production immediately and is auto-merged forward into `next-release` (see `.github/workflows/main.yml`); `next-release` only reaches production later, when a maintainer opens a release PR and squashes it into `release`. So the real question is "should this go live right now, or wait for the next release cutover?", not what kind of file you touched — `contribute/en/` and `_posts/` changes have gone directly to `release` in some PRs and to `next-release` in others.
-- Before opening the PR, check recent precedent for files like the ones you're touching, e.g. `gh pr list --repo jamulussoftware/jamuluswebsite --base release --state merged --limit 30 --json title,files` and the same with `--base next-release`. If you still can't tell, say so explicitly in the PR description and let a maintainer redirect it rather than guessing silently.
-- When truly unsure and precedent doesn't settle it, default to `next-release` — an off-base call there is cheap to correct before it ever goes live, unlike one on `release`.
+- Branch: `release` publishes immediately and merges forward; `next-release` waits for the next release cutover. Ask "should this be live now?", not "what file did I touch?". Check precedent for similar files in recent merged PRs. If unsure, use `next-release` - a wrong call there is cheap to correct.
 - Fill out the PR template checklist.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ This is documentation, not code. The bar is: **is this better than what is there
 ## Rules
 
 - Edit English source `.md` files only. Never hand-edit translated files or `.po` files - those belong to translators via Weblate.
-- Plain ASCII (`-` `'` `"`) inside anything parsed or copy-pasted: code, CLI flags, URLs, frontmatter, dates, versions. Autocorrect and LLM output break this by default; check your diff.
+- Plain ASCII (`-` `'` `"`) inside anything parsed or copy-pasted: code, CLI flags, URLs, frontmatter, dates, versions. Autocorrect and LLM output break this by default; check your diff. See the Punctuation section of the Style and Tone guide.
 - British English spelling (colour, minimise, centre).
 
 ## Submitting

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,5 +20,5 @@ This is documentation, not code. The bar is: **is this better than what is there
 
 ## Submitting
 
-- Branch: `release` publishes immediately and merges forward; `next-release` waits for the next release cutover. Ask "should this be live now?", not "what file did I touch?". Check precedent for similar files in recent merged PRs. If unsure, use `next-release` - a wrong call there is cheap to correct.
+- Branch: `next-release` unless you have a reason. `release` is the live site and publishes immediately; `next-release` waits for the next release cutover. Anything under `wiki/` must go to `next-release` - it is the only tree that gets translated, and it has to wait for the translation sprint. Blog posts under `_posts/` and urgent build fixes go to `release`.
 - Fill out the PR template checklist.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,5 +15,7 @@ Docs: [README.md](README.md) (workflow, translation process, branch targeting), 
 
 ## Submit
 
-- Target `next-release` if the change needs translation, `release` if not (README's workflow section explains which).
+- Branch targeting is genuinely case by case (maintainers' own assessment) — there's no reliable rule like "translated content → next-release." Mechanically: a merge to `release` publishes to production immediately and is auto-merged forward into `next-release` (see `.github/workflows/main.yml`); `next-release` only reaches production later, when a maintainer opens a release PR and squashes it into `release`. So the real question is "should this go live right now, or wait for the next release cutover?", not what kind of file you touched — `contribute/en/` and `_posts/` changes have gone directly to `release` in some PRs and to `next-release` in others.
+- Before opening the PR, check recent precedent for files like the ones you're touching, e.g. `gh pr list --repo jamulussoftware/jamuluswebsite --base release --state merged --limit 30 --json title,files` and the same with `--base next-release`. If you still can't tell, say so explicitly in the PR description and let a maintainer redirect it rather than guessing silently.
+- When truly unsure and precedent doesn't settle it, default to `next-release` — an off-base call there is cheap to correct before it ever goes live, unlike one on `release`.
 - Fill out the PR template checklist.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Content repo for jamulus.app. English is the source of truth: edits land in English first, then flow to other languages via Weblate/po4a.
 
-Read first: [README.md](README.md) (workflow, translation, branches) and the [Style and Tone guide](https://jamulus.io/contribute/Style-and-Tone) (voice, terminology, spelling). The guide governs; this file does not restate or override it.
+Read first: [README.md](README.md) (workflow, translation, branches) and the [Style and Tone guide](https://jamulus.app/contribute/Style-and-Tone) (voice, terminology, spelling). The guide governs; this file does not restate or override it.
 
 ## Changes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,5 +20,6 @@ This is documentation, not code. The bar is: **is this better than what is there
 
 ## Submitting
 
-- Branch: `next-release` unless you have a reason. `release` is the live site and publishes immediately; `next-release` waits for the next release cutover. Anything under `wiki/` must go to `next-release` - it is the only tree that gets translated, and it has to wait for the translation sprint. Blog posts under `_posts/` and urgent build fixes go to `release`.
+- Branch: `next-release` unless you have a reason. `release` is the live site and publishes immediately; `next-release` waits for the next release cutover. Anything under `wiki/en/` must go to `next-release` - it is the only tree that gets translated, and it has to wait for the translation sprint. Submit English only; the other languages are produced from it by translators. Blog posts under `_posts/` and urgent build fixes go to `release`.
 - Fill out the PR template checklist.
+- Disclose AI-generated text at the end of the PR description and of comments (e.g. `> 🤖 Used AI: <model>, <harness>`). The person submitting remains the author and answers for every line.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Jamulus Website - Agent Instructions
 
-Content repo for jamulus.io. English is the source of truth: edits land in English first, then flow to other languages via Weblate/po4a.
+Content repo for jamulus.app. English is the source of truth: edits land in English first, then flow to other languages via Weblate/po4a.
 
 Read first: [README.md](README.md) (workflow, translation, branches) and the [Style and Tone guide](https://jamulus.io/contribute/Style-and-Tone) (voice, terminology, spelling). The guide governs; this file does not restate or override it.
 

--- a/contribute/en/Style-and-Tone.md
+++ b/contribute/en/Style-and-Tone.md
@@ -101,21 +101,6 @@ Jamulus is "Free and Open Source (FOSS)" (not "free software" or "open source")
 
 "Server List" This is the list of Servers maintained by a Directory.  A Server registers with a Directory to be _listed_ in that Directory’s _server list_.
 
-## Punctuation
-
-One governing question for every dash, quote, or ellipsis: is this character doing a job a parser depends on, or is it doing prose work for a human reader? Machine-context wins every time; only prose gets the fancier character.
-
-Never use a curly/typographic character inside a code span or fenced code block, an HTML attribute, YAML frontmatter, a CLI flag, a Markdown list/checkbox bullet, an ISO 8601 date (`2021-03-17`), a version/build string (`3.7.0dev-123456`), a URL, or anything meant to be copied and pasted verbatim (a shell command, a JSON snippet, a config value). In all of these, a smart quote, em-dash, or en-dash is either a parser error or a silent corruption of a value the reader will paste elsewhere. Plain ASCII `-`, `'`, `"` only.
-
-Everywhere else — prose meant to be read, not executed — use the correct typographic character:
-
-- **Hyphen (`-`)**: compound modifiers only (`low-bandwidth`, `text-wrapping`). If you can mentally replace it with "to" or read it as a parenthetical break, it isn't a hyphen's job.
-- **En dash (`–`), no surrounding spaces**: numeric ranges (`0–16`, `30–50 ms`, `pages 16–18`).
-- **En dash (`–`), with spaces**: a "Title – Subtitle" page title, matching the existing pattern in `Command-Line-Options.md`, `Privacy-Statement.md`, and `2020-03-28-Server-Rpi.md`.
-- **Em dash (`—`), with spaces on both sides**: a parenthetical aside, appositive, or sentence interruption — matches the site's own pre-existing usage (`misc/1-index.md`). Never use a doubled hyphen (`--`) as a substitute; it's a typewriter-era workaround, not a typographic period.
-- **Curly quotes/apostrophes (`’ “ ”`)**: prose, including quoted UI labels read by a human (`click "Learn"`) — never a value the reader is meant to type or paste.
-- **Ellipsis**: use the single `…` character in narrative prose. Exception — when quoting an app's literal UI string that itself ends in three dots (`"File > Connection Setup..."`, `"My Profile..."`), reproduce it exactly; don't "correct" a real menu label.
-
 ## Units
 
 We use the following abbreviations:

--- a/contribute/en/Style-and-Tone.md
+++ b/contribute/en/Style-and-Tone.md
@@ -101,6 +101,21 @@ Jamulus is "Free and Open Source (FOSS)" (not "free software" or "open source")
 
 "Server List" This is the list of Servers maintained by a Directory.  A Server registers with a Directory to be _listed_ in that Directory’s _server list_.
 
+## Punctuation
+
+One governing question for every dash, quote, or ellipsis: is this character doing a job a parser depends on, or is it doing prose work for a human reader? Machine-context wins every time; only prose gets the fancier character.
+
+Never use a curly/typographic character inside a code span or fenced code block, an HTML attribute, YAML frontmatter, a CLI flag, a Markdown list/checkbox bullet, an ISO 8601 date (`2021-03-17`), a version/build string (`3.7.0dev-123456`), a URL, or anything meant to be copied and pasted verbatim (a shell command, a JSON snippet, a config value). In all of these, a smart quote, em-dash, or en-dash is either a parser error or a silent corruption of a value the reader will paste elsewhere. Plain ASCII `-`, `'`, `"` only.
+
+Everywhere else — prose meant to be read, not executed — use the correct typographic character:
+
+- **Hyphen (`-`)**: compound modifiers only (`low-bandwidth`, `text-wrapping`). If you can mentally replace it with "to" or read it as a parenthetical break, it isn't a hyphen's job.
+- **En dash (`–`), no surrounding spaces**: numeric ranges (`0–16`, `30–50 ms`, `pages 16–18`).
+- **En dash (`–`), with spaces**: a "Title – Subtitle" page title, matching the existing pattern in `Command-Line-Options.md`, `Privacy-Statement.md`, and `2020-03-28-Server-Rpi.md`.
+- **Em dash (`—`), with spaces on both sides**: a parenthetical aside, appositive, or sentence interruption — matches the site's own pre-existing usage (`misc/1-index.md`). Never use a doubled hyphen (`--`) as a substitute; it's a typewriter-era workaround, not a typographic period.
+- **Curly quotes/apostrophes (`’ “ ”`)**: prose, including quoted UI labels read by a human (`click "Learn"`) — never a value the reader is meant to type or paste.
+- **Ellipsis**: use the single `…` character in narrative prose. Exception — when quoting an app's literal UI string that itself ends in three dots (`"File > Connection Setup..."`, `"My Profile..."`), reproduce it exactly; don't "correct" a real menu label.
+
 ## Units
 
 We use the following abbreviations:

--- a/contribute/en/Style-and-Tone.md
+++ b/contribute/en/Style-and-Tone.md
@@ -10,6 +10,8 @@ permalink: "/contribute/Style-and-Tone"
 
 While contributing to Jamulus or the website, you should also keep style and tone in mind. Have a look at the following guidelines.
 
+These guidelines apply to every contribution, including work drafted with AI assistance. The `AGENTS.md` file in the website repository points automated contributors here rather than repeating them, so this page stays the single source of truth.
+
 **Note:** It is very important to thoroughly proofread content before submitting it, as any corrections made later have a knock-on effect on translations.
 
 <details markdown="1">
@@ -100,6 +102,16 @@ Jamulus is "Free and Open Source (FOSS)" (not "free software" or "open source")
 "Registration" When a Server is configured in Registered mode, it will be _listed_ when successfully registered by a Directory. Note that if a Directory is full, a Registered Server will not be _listed_ because it has not been successfully _registered_. Note in this case we prefer to say, "Register with a Directory".
 
 "Server List" This is the list of Servers maintained by a Directory.  A Server registers with a Directory to be _listed_ in that Directory’s _server list_.
+
+## Punctuation
+
+Content here is written for people, but parts of it are read by tools as well. Keep the two apart.
+
+Inside anything a reader will copy or a tool will parse - code spans and fenced blocks, command-line flags, URLs, file paths, YAML frontmatter, HTML attributes, dates and version strings - use plain ASCII `-`, `'` and `"` only. A curly quote or a long dash pasted into a shell command, a config file or a search box is not the character the tool expects, and it fails in ways the reader cannot see. Word processors and AI writing tools insert those characters automatically, so check your work before submitting.
+
+In prose, plain ASCII is the safe default and most pages already use it. Where a typographic character genuinely helps the reader it is acceptable, but it is never required. Do not convert a page from one style to the other as a change of its own: that produces a large diff with no benefit to the reader, and churn for translators.
+
+When quoting a literal label from the app, reproduce it exactly, including any trailing dots ("File > Connection Setup..."). Do not correct a real menu label.
 
 ## Units
 

--- a/contribute/en/Style-and-Tone.md
+++ b/contribute/en/Style-and-Tone.md
@@ -86,9 +86,9 @@ Refer to UI labels in inverted commas (e.g. 'click on the "Mute" button')
 
 Jamulus is "Free and Open Source (FOSS)" (not "free software" or "open source")
 
-"Channel" The audio signal as part of a mix. "Mute a channel", "Maximum number of channels", "Group channels together" (not "Mute a person" because one person might be using multiple channels).
+"Channel" The audio signal as part of a mix. "Mute a channel", "Maximum number of channels" (not "Mute a person" because one person might be using multiple channels).
 
-"Fader" The UI that controls a channel. "Each fader has a "Mute" button", "The person’s fader" ,"Group faders together" (not "The person’s channel" or "Mute a Fader", not "Slider" or "Volume control")
+"Fader" The UI that controls a channel. "Each fader has a "Mute" button", "The person’s fader", "Group faders together" (not "The person’s channel" or "Mute a Fader", not "Slider" or "Volume control"). Grouping is a fader feature: moving one fader moves the others in its group, and each one sets its own channel’s gain.
 
 "Person" A human connected to a server (may be on multiple channels). We might say "a person on the server", or "the people who have muted themselves", rather than _musicians_ or _Channels_.
 

--- a/contribute/en/Style-and-Tone.md
+++ b/contribute/en/Style-and-Tone.md
@@ -10,7 +10,9 @@ permalink: "/contribute/Style-and-Tone"
 
 While contributing to Jamulus or the website, you should also keep style and tone in mind. Have a look at the following guidelines.
 
-These guidelines apply to every contribution, including work drafted with AI assistance. The `AGENTS.md` file in the website repository points automated contributors here rather than repeating them, so this page stays the single source of truth.
+These guidelines apply to every contribution, including work drafted with AI assistance.
+
+Note: The `AGENTS.md` file in the website repository points automated contributors here, so this page stays the single source of truth.
 
 **Note:** It is very important to thoroughly proofread content before submitting it, as any corrections made later have a knock-on effect on translations.
 

--- a/contribute/en/Style-and-Tone.md
+++ b/contribute/en/Style-and-Tone.md
@@ -109,7 +109,7 @@ Jamulus is "Free and Open Source (FOSS)" (not "free software" or "open source")
 
 ## Punctuation
 
-Content here is written for people, but parts of it are read by tools as well. Keep the two apart.
+Content here is written for people, and some of it gets pasted into tools: commands, paths, configuration. Punctuation that reads fine on the page can break once pasted.
 
 Inside anything a reader will copy or a tool will parse - code spans and fenced blocks, command-line flags, URLs, file paths, YAML frontmatter, HTML attributes, dates and version strings - use plain ASCII `-`, `'` and `"` only. A curly quote or a long dash pasted into a shell command, a config file or a search box is not the character the tool expects, and it fails in ways the reader cannot see. Word processors and AI writing tools insert those characters automatically, so check your work before submitting.
 

--- a/contribute/en/Style-and-Tone.md
+++ b/contribute/en/Style-and-Tone.md
@@ -14,6 +14,8 @@ These guidelines apply to every contribution, including work drafted with AI ass
 
 Note: The `AGENTS.md` file in the website repository points automated contributors here, so this page stays the single source of truth.
 
+As in the [Jamulus repository](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#ownership), the person who submits a change is its author and owner: understand and stand behind every line, and answer the questions reviewers direct at you. Disclose AI-generated text at the end of a pull request description or comment, for example `> 🤖 Used AI: <model>, <harness>`.
+
 **Note:** It is very important to thoroughly proofread content before submitting it, as any corrections made later have a knock-on effect on translations.
 
 <details markdown="1">

--- a/contribute/en/Style-and-Tone.md
+++ b/contribute/en/Style-and-Tone.md
@@ -47,7 +47,7 @@ Jamulus has users of varying skill levels ranging from complete beginner to audi
 ### Avoid using slang and euphemisms.
  {:.no_toc}
 
-Jamulus is used around the world and translated in five languages (possibly more!). Use plain english to provide users and translators an easier understanding of our content.
+Jamulus is used around the world and translated in many languages. Use plain english to provide users and translators an easier understanding of our content.
 
 ### Give solutions first.
  {:.no_toc}

--- a/contribute/en/Style-and-Tone.md
+++ b/contribute/en/Style-and-Tone.md
@@ -32,7 +32,7 @@ As in the [Jamulus repository](https://github.com/jamulussoftware/jamulus/blob/m
 ### Keep it concise and specific.
  {:.no_toc}
 
-Avoid long-winded phrases and overly stylised language. Start simple, expand to details later, if at all ("inverted pyramid" style).
+Avoid long-winded phrases and overly stylised language. Start simple, expand to details later, if at all.
 
 ### Be direct, but not demanding.
  {:.no_toc}
@@ -65,9 +65,6 @@ Resist the temptation to say why something happens before offering a solution fo
 Informal English is preferred (e.g. "haven’t" not "have not". "Try to" not "Please attempt to").
 
 Try not to sound like a robot. Write conversationally, as if you were talking to a person.
-
-
-
 
 ## Capitalisation and references
 


### PR DESCRIPTION
**🤖 AI:** **Short description of changes**
Adds a top-level `AGENTS.md`, mirroring the pattern already in progress for the main [jamulus](https://github.com/jamulussoftware/jamulus) repo (see jamulussoftware/jamulus#3793 / #3789). It points agents at the existing README workflow and Style-and-Tone guide, and adds one rule that isn't covered by either: no smart/curly quotes or apostrophes.

Rationale for that rule: a curly `’`/`“”` pasted into a shell single-quoted string, JSON, a regex, or a code span is not the character the parser expects, and corrupts it silently — this is a real, machine-readable-content risk (unlike e.g. em-dash-vs-hyphen debates, which are purely a human-rendered typography/taste question with no parsing consequence in this repo's kramdown/GFM setup, so deliberately left out).

**Context: Fixes an issue? Related issues**
No related issue.

**Status of this Pull Request**
Ready for review. Every review thread opened so far has been addressed in the branch: @ann0see's two suggestion blocks are applied (`9259b3cc`) and his branch-clarification ask is at `AGENTS.md:23`; @pljones's Style-and-Tone comments are answered at `c3359a2c` and `de3df071`.

**What is missing until this pull request can be merged?**
A re-review. The PR carries `CHANGES_REQUESTED` from a review whose asks are now applied, and that state clears only on a new review.

**Does this need translation?**
NO — agent-facing repo doc, not user-facing site content (same category as README.md).

## Checklist
- [x] I've verified that this Pull Request follows the general code principles
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors.
- [x] I'm sure that this Pull Request goes to the correct branch

---

🤖 *This message was written by AI and reviewed by @mcfnord.*
