### PR TITLE
Feature/issue 1094 weblate block

### DIFF
--- a/.github/workflows/check-weblate-prs.yml
+++ b/.github/workflows/check-weblate-prs.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           # The exact username of the Weblate bot (e.g., 'weblate', 'app/weblate')
           # You may need to check a previous Weblate PR to confirm the exact author name.
-          WEBLATE_AUTHOR="app/weblate" 
+          WEBLATE_AUTHOR="weblate" 
           
           echo "Checking $REPO for open PRs from $WEBLATE_AUTHOR..."
           

--- a/.github/workflows/check-weblate-prs.yml
+++ b/.github/workflows/check-weblate-prs.yml
@@ -1,0 +1,40 @@
+name: Block EN Merges on Active Weblate PRs
+
+on:
+  pull_request:
+    # Triggers the check only when source documentation is modified.
+    # Adjust these paths based on where the English source files live in the repo.
+    paths:
+      - '**/*.md'
+      - '_pages/**'
+      - '_posts/**'
+
+jobs:
+  check-weblate:
+    name: Evaluate Weblate PR Status
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+
+    steps:
+      - name: Check for open Weblate pull requests
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          # The exact username of the Weblate bot (e.g., 'weblate', 'app/weblate')
+          # You may need to check a previous Weblate PR to confirm the exact author name.
+          WEBLATE_AUTHOR="app/weblate" 
+          
+          echo "Checking $REPO for open PRs from $WEBLATE_AUTHOR..."
+          
+          # Query GitHub API for open PRs from the bot, output as JSON, and count the array length
+          OPEN_PRS=$(gh pr list --repo "$REPO" --state open --author "$WEBLATE_AUTHOR" --json number -q '. | length')
+          
+          if [ "$OPEN_PRS" -gt 0 ]; then
+            echo "::error::Found $OPEN_PRS open Weblate PR(s). Merging changes to English documentation is blocked to prevent po4a translation conflicts."
+            exit 1
+          else
+            echo "No open Weblate PRs detected. Safe to proceed."
+            exit 0
+          fi

--- a/.github/workflows/check-weblate-prs.yml
+++ b/.github/workflows/check-weblate-prs.yml
@@ -2,12 +2,8 @@ name: Block EN Merges on Active Weblate PRs
 
 on:
   pull_request:
-    # Triggers the check only when source documentation is modified.
-    # Adjust these paths based on where the English source files live in the repo.
     paths:
-      - '**/*.md'
-      - '_pages/**'
-      - '_posts/**'
+      - 'wiki/en/**'
 
 jobs:
   check-weblate:

--- a/.github/workflows/check-weblate-prs.yml
+++ b/.github/workflows/check-weblate-prs.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   check-weblate:
     name: Evaluate Weblate PR Status
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     permissions:
       pull-requests: read
 
@@ -18,13 +18,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
-          # The exact username of the Weblate bot (e.g., 'weblate', 'app/weblate')
-          # You may need to check a previous Weblate PR to confirm the exact author name.
           WEBLATE_AUTHOR="weblate" 
           
           echo "Checking $REPO for open PRs from $WEBLATE_AUTHOR..."
           
-          # Query GitHub API for open PRs from the bot, output as JSON, and count the array length
           OPEN_PRS=$(gh pr list --repo "$REPO" --state open --author "$WEBLATE_AUTHOR" --json number -q '. | length')
           
           if [ "$OPEN_PRS" -gt 0 ]; then


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
Adds a new GitHub Actions workflow (`check-weblate-prs.yml`) that triggers on pull requests modifying English documentation. It uses the GitHub CLI to query if there are any open PRs authored by the Weblate bot. If an active Weblate PR is found, the workflow intentionally fails the status check to block the merge and prevent po4a translation conflicts.

**Context: Fixes an issue? Related issues**
Fixes #1094 

**Status of this Pull Request**
Working implementation (Draft / Testing pipeline execution).

**What is missing until this pull request can be merged?**
Because I am a first-time contributor, a maintainer will likely need to click "Approve and run" on the Actions tab so the CI pipeline can execute. I want to verify that the Bash script correctly identifies the exact Weblate bot author name used in this repository before marking this as ready for review.

**Does this need translation?**
NO. 

<!-- Does your pull request need translation? If you type "YES", please open a pull request to the next-release branch, otherwise to release. Usually, Pull Requests to release are only for typos in a specific language or if you changed something for every language -->

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I'm sure that this Pull Request goes to the correct branch