### PR TITLE
Software Manual: separate input and output device selection on macOS

### DIFF
--- a/assets/img/en-screenshots/input-output-devices-macos.inc
+++ b/assets/img/en-screenshots/input-output-devices-macos.inc
@@ -1,0 +1,1 @@
+https://github.com/user-attachments/assets/c3a53a83-8617-4df5-8201-9b7777fd7c96

--- a/wiki/en/Software-Manual.md
+++ b/wiki/en/Software-Manual.md
@@ -224,8 +224,20 @@ This turns on a sound alert for when someone joins a Server, or when receiving a
 
 ### Audio Device
 
+What you see here depends on your operating system. On macOS there are two menus, "Input Device" and "Output Device", described below. On every other platform there is a single "Audio Device" menu.
+
 Under the Windows operating system the ASIO driver (sound card) can be selected using Jamulus. If the selected ASIO
-driver is not valid an error message is shown and the previous valid driver is selected. Under macOS the input and output hardware can be selected.
+driver is not valid an error message is shown and the previous valid driver is selected.
+
+### Input and output devices on macOS
+
+On macOS you choose your sound hardware in two menus rather than one. "Input Device" sets what Jamulus listens to, and "Output Device" sets what you hear through. They don't have to be the same piece of hardware, so you can play through an audio interface and listen through your computer's built-in output if you prefer.
+
+Each menu only lists hardware that can do that job, so a pair of speakers won't show up under "Input Device".
+
+Choose "System Default In Device" or "System Default Out Device" to use whatever is set in the macOS Sound settings when Jamulus starts.
+
+Changing one of the menus leaves the other one alone, along with its channel mapping.
 
 ### Input/output channel mapping
 

--- a/wiki/en/Software-Manual.md
+++ b/wiki/en/Software-Manual.md
@@ -231,6 +231,8 @@ driver is not valid an error message is shown and the previous valid driver is s
 
 ### Input and output devices on macOS
 
+<figure><img src="{% include img/en-screenshots/input-output-devices-macos.inc %}" style="float:left; margin-right:10px; margin-bottom:20px;" loading="lazy" alt="Image of the input and output device menus on macOS"></figure>
+
 On macOS you choose your sound hardware in two menus rather than one. "Input Device" sets what Jamulus listens to, and "Output Device" sets what you hear through. They don't have to be the same piece of hardware, so you can play through an audio interface and listen through your computer's built-in output if you prefer.
 
 Each menu only lists hardware that can do that job, so a pair of speakers won't show up under "Input Device".


### PR DESCRIPTION
**Disclosure**

This change was written with Claude (Claude Code); the commits carry `Co-Authored-By: Claude Opus 5` trailers, the same as jamulussoftware/jamulus#3908. I set the goal and the constraints and reviewed the wording line by line against the [style guide](https://jamulus.io/contribute/Style-and-Tone); the screenshot is from my own machine. Noting it for transparency, not as a substitute for your review.

**Short description of changes**

Documents the change in jamulussoftware/jamulus#3908, which replaces the single "Audio Device" menu on macOS with separate "Input Device" and "Output Device" menus. @pljones asked for the documentation to land alongside it.

Adds a short section under Settings / Audio-Network Setup describing the two menus, and reworks the opening of "Audio Device" so it names both layouts up front rather than describing the Windows one and mentioning macOS as an aside. The existing sentence about ASIO is unchanged, so its translations are unaffected.

Two commits: the text, then the screenshot.

**Context: Fixes an issue? Related issues**

Documents jamulussoftware/jamulus#3908, requested in https://github.com/jamulussoftware/jamulus/pull/3908#issuecomment-5372523499.

**Status of this Pull Request**

Working implementation. Depends on jamulussoftware/jamulus#3908 — please don't merge before it, or the manual will describe a dialog that isn't shipped yet.

**What is missing until this pull request can be merged?**

Review. Built locally with Jekyll and checked in a browser: the new section renders and the image loads. The screenshot is macOS 26.5, 295 x 136.

**Does this need translation?**

YES - hence targeting `next-release`. Four new paragraphs and one new heading; one existing sentence loses a trailing clause that described the old macOS behaviour.

## Checklist

- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors.
- [x] I'm sure that this Pull Request goes to the correct branch
